### PR TITLE
chore: add form style and upgrade antd to 4.22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 *~
 ~*
 *.diff
-*.patch
 *.bak
 .DS_Store
 Thumbs.db

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "pretty-quick": "pretty-quick",
     "site": "bisheng start -c ./site/bisheng.config.js",
     "build": "gulp color-theme && npm run site",
+    "postinstall": "patch-package",
     "start": "cross-env NODE_ENV=development concurrently \"gulp color-theme\" \"npm run site\""
   },
   "browserslist": [
@@ -58,7 +59,7 @@
     "@types/react": "^16.9.41",
     "@types/react-color": "^3.0.4",
     "@types/react-dom": "^16.9.5",
-    "antd": "4.4.0",
+    "antd": "4.22.8",
     "antd-img-crop": "^3.9.0",
     "babel-plugin-add-react-displayname": "^0.0.5",
     "bisheng": "^1.6.1",
@@ -83,6 +84,7 @@
     "less-plugin-autoprefix": "^2.0.0",
     "less-plugin-npm-import": "^2.1.0",
     "lz-string": "^1.4.4",
+    "patch-package": "^6.5.1",
     "plugin-error": "^1.0.1",
     "prettier": "^2.0.1",
     "pretty-quick": "^2.0.0",

--- a/patches/antd+4.22.8.patch
+++ b/patches/antd+4.22.8.patch
@@ -1,0 +1,26 @@
+diff --git a/node_modules/antd/lib/table/style/index-pure.less b/node_modules/antd/lib/table/style/index-pure.less
+index 5ee1217..084ce2e 100644
+--- a/node_modules/antd/lib/table/style/index-pure.less
++++ b/node_modules/antd/lib/table/style/index-pure.less
+@@ -718,7 +718,7 @@
+       z-index: @table-sticky-zindex;
+       display: flex;
+       align-items: center;
+-      background: lighten(@table-border-color, 80%);
++      background: @table-border-color;
+       border-top: 1px solid @table-border-color;
+       opacity: 0.6;
+ 
+diff --git a/node_modules/antd/lib/tooltip/style/index-pure.less b/node_modules/antd/lib/tooltip/style/index-pure.less
+index d2ad5e1..5586eb3 100644
+--- a/node_modules/antd/lib/tooltip/style/index-pure.less
++++ b/node_modules/antd/lib/tooltip/style/index-pure.less
+@@ -84,7 +84,7 @@
+       // Use linear gradient to mix box shadow of tooltip inner
+       --antd-arrow-background-color: linear-gradient(
+         to right bottom,
+-        fadeout(@tooltip-bg, 10%),
++        @tooltip-bg,
+         @tooltip-bg
+       );
+ 

--- a/site/theme/template/Icon/index.jsx
+++ b/site/theme/template/Icon/index.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import AntdIcon, { createFromIconfontCN } from '@ant-design/icons';
 
 import { withThemeSuffix, removeTypeTheme, getThemeFromTypeName } from './utils';
-import warning from 'antd/lib/_util/devWarning';
+import warning from 'antd/lib/_util/warning';
 
 const IconFont = createFromIconfontCN({
   scriptUrl: '//at.alicdn.com/t/font_1329669_t1u72b9zk8s.js',

--- a/site/theme/template/Icon/utils.js
+++ b/site/theme/template/Icon/utils.js
@@ -1,4 +1,4 @@
-import warning from 'antd/lib/_util/devWarning';
+import warning from 'antd/lib/_util/warning';
 
 // These props make sure that the SVG behaviours like general text.
 // Reference: https://blog.prototypr.io/align-svg-icons-to-text-and-say-goodbye-to-font-icons-d44b3d7b26b4

--- a/src/form.less
+++ b/src/form.less
@@ -1,0 +1,1 @@
+@label-color: var(--foreground);

--- a/src/index.less
+++ b/src/index.less
@@ -15,3 +15,4 @@
 @import './modal.less';
 @import './table.less';
 @import './steps.less';
+@import './form.less';


### PR DESCRIPTION
1. 增加 form 和 table 的适配样式
2. 升级 antd 4.x 到 4.22.8 最新版本，样式粗略测试是向后兼容，不过保险起见，之后可以发布 @opensumi/antd-theme 2.0.0 的版本